### PR TITLE
Added computation of phase-based coupling.

### DIFF
--- a/feature.py
+++ b/feature.py
@@ -1,0 +1,28 @@
+
+import os
+import numpy as np
+from pyedr import Dataset
+from pyedr.ekg import Ekg
+from pyedr.resp import Resp
+from pyedr.coupling import Coupling
+import matplotlib.pyplot as plt
+
+
+fs = 250
+def get_data():
+    num_samples = fs * 30
+    ds = Dataset(subject_ids=['synthetic'],
+                       num_of_segments=4,
+                       sampling_rate=fs,
+                       num_samples=num_samples,
+                       esk_strength=0.0)
+    X = ds.get_data()
+    EKG  = [x[0] for x in X]
+    RESP = [x[1] for x in X]
+    return EKG, RESP
+
+ekg, resp = get_data()
+ekg = Ekg(ekg, fs)
+resp = Resp(resp, fs)
+c = Coupling(ekg, resp)
+c.plot()

--- a/pyedr/coupling.py
+++ b/pyedr/coupling.py
@@ -1,0 +1,81 @@
+
+from . import ekg
+from . import resp
+import numpy as np
+from scipy.optimize import fmin
+
+pi2 = 2 * np.pi
+
+class Coupling:
+    """ Compute phase-amplitude coupling btw EKG and RESP
+    Args:
+        EKG: iterable of EKG signals, or ekg.Ekg object.
+        RESP: iterable of RESP signals, or resp.Resp object.
+            There should be the same amount of EKG and RESP signals.
+        sampling_rate: sampling rate of both signals, unless objects
+            are given. (default None)
+    """
+    
+    def __init__(self, EKG, RESP, sampling_rate=None):
+        if type(EKG) is not ekg.Ekg:
+            assert sampling_rate is not None, "s-rate required to build ekg.Ekg object."
+            self.EKG = ekg.Ekg(EKG, sampling_rate)
+        else:
+            self.EKG = EKG
+        if type(RESP) is not resp.Resp:
+            assert sampling_rate is not None, "s-rate required to build resp.Resp object."
+            self.RESP = resp.Resp(RESP, sampling_rate)
+        else:
+            self.RESP = RESP
+        assert len(self.EKG.segments) == len(self.RESP.segments), "Incompatible EKG and RESP series."
+        self.EKG.get_all_R_peaks()
+        self.RESP.get_all_phases()
+        self.compute_coupling()
+
+    def compute_coupling(self):
+        EKG = self.EKG
+        RESP = self.RESP
+        phi_j = [phase[idx] for phase, idx in zip(RESP.phase, EKG.R_peaks)]
+        phi_j = self.phi_j = np.concatenate(phi_j)
+        rri = self.rri = np.concatenate(EKG.R_intervals)
+        rph = self.rph = np.concatenate(EKG.R_peak_heights)
+
+        self.p_rri, self.res_rri = self.fit_sinfunc(phi_j, rri)
+        self.p_rph, self.res_rph = self.fit_sinfunc(phi_j, rph)
+
+        self.compute_snr()
+
+    def compute_snr(self):
+        self.snr_rri = abs(self.p_rri[1])/self.res_rri
+        self.snr_rph = abs(self.p_rph[1])/self.res_rph
+
+    def plot(self):
+        import matplotlib.pyplot as plt
+        ph = np.arange(0, pi2, 0.1)
+        ax = plt.subplot(211)
+        plt.title("RSA-Coupling:  SNR={:.3g}".format(self.snr_rri))
+        plt.plot(ph, self.sinfunc(ph, self.p_rri))
+        plt.plot(self.phi_j, self.rri, 'ko')
+        plt.ylabel("R-R Intervals (sec.)")
+        plt.subplot(212, sharex=ax)
+        plt.title("ESK-Coupling:  SNR={:.3g}".format(self.snr_rph))
+        plt.plot(ph, self.sinfunc(ph, self.p_rph))
+        plt.plot(self.phi_j, self.rph, 'ko')
+        plt.ylabel("R-Peak Height (mV)")
+        plt.xlim(0, pi2)
+        plt.show()
+
+    @staticmethod
+    def sinfunc(phi, p):
+        return p[0] + p[1]*np.sin(phi-p[2])
+
+    @classmethod
+    def erf(cls, p, phi, f):
+        return np.mean((cls.sinfunc(phi, p)-f)**2)
+
+    @classmethod
+    def fit_sinfunc(cls, phase, f):
+        p_init = [np.mean(f), np.sqrt(2)*np.std(f), np.pi]    
+        p_opt = fmin(cls.erf, p_init, args=(phase, f))
+        residual = np.sqrt(cls.erf(p_opt, phase, f))
+        return p_opt, residual

--- a/pyedr/resp.py
+++ b/pyedr/resp.py
@@ -1,0 +1,79 @@
+
+import numpy as np
+from scipy.signal import butter, filtfilt, hilbert, detrend
+from fastcache import clru_cache
+
+pi2 = 2.0*np.pi
+
+@clru_cache(maxsize=256)
+def low_pass_filter(f_max, sampling_rate):
+        return butter(4, 2.0 * f_max/float(sampling_rate), btype='low')
+
+class Resp:
+
+    low_pass_frequency = 15.0
+    threshold = 1.5
+    rri_threshold = 0.300
+
+    def __init__(self, segments, sampling_rate):
+        self.sampling_rate = sampling_rate
+        self.segments = segments
+        self.num_segments = len(self.segments)
+        self.phase_computed = False
+        self.compute_real_phase = True
+
+    @property
+    def phase(self):
+        assert self.phase_computed, "Call get_all_phases() first."
+        return self._phase
+
+    def plot(self):
+        import matplotlib.pyplot as plt
+        signal = self.segments[0]
+        phase = self.phase[0]
+        t = np.arange(signal.size)/float(self.sampling_rate)
+        ax = plt.subplot(211)
+        plt.plot(t, signal)
+        plt.subplot(212, sharex=ax)
+        plt.plot(t, phase, 'k-')
+        plt.show()
+
+    def filter(self, signal):
+        b, a = low_pass_filter(self.low_pass_frequency, self.sampling_rate)
+        return filtfilt(b, a, signal)
+
+    def get_prophase(self, x):
+        xf = detrend(self.filter(x))
+        return np.mod(np.angle(hilbert(xf)), pi2)
+
+    def phase_from_prophase(self):
+        """ Transform a pro-phase to a real phase
+
+        The real phase has the property to rotate uniformly, leading to a
+        uniform distribution density.  The prophase typically doesn't fulfill
+        this property.  The following lines apply a nonlinear transformation to
+        the phase signal that makes its distribution exactly uniform.
+        """
+        # Pool prophases from sequence
+        phi = np.concatenate(self.phase)
+        # Get a sorting index
+        sort_idx = np.argsort(phi)
+        # Get index reversing sorting
+        reverse_idx = np.argsort(sort_idx)
+        # Set up sorted real phase
+        tht = pi2 * np.arange(phi.size)/(phi.size)
+        # Reverse the sorting of it
+        real_phase = tht[reverse_idx]
+        # Now put in sequence again
+        indices = np.cumsum([0]+[ph.size for ph in self.phase])
+        self._phase = [real_phase[s:e] for s, e in zip(indices[:-1], indices[1:])]
+
+    def get_all_phases(self):
+        assert not self.phase_computed
+        self._phase = [
+                self.get_prophase(x)
+                for x in self.segments
+            ]
+        self.phase_computed = True
+        if self.compute_real_phase:
+            self.phase_from_prophase()

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ numpy>=1.12.0
 scipy
 biosppy
 namedlist
+fastcache>=1.0.1
 
 # Packages on github
 # pyedf install from github.com/jusjusjus/pyedf.git


### PR DESCRIPTION
This commit adds two classes: Resp, and Coupling.

class Resp:

Resp is, similar to Ecg, processing Resp time-series, and making their
features available, here mostly the phase variable.  Resp is initialized
by a list of resp segments.  The class also impliments a pro-to-real
phase trafo.

For Coupling.compute_real_phase=True, the pro-to-real phase
transformation is applied to all segments.

Functionality
- Resp.get_all_phases: computes the phase for each segment separately
  using the Hilbert transform.

class Coupling:

Coupling is initialized with lists of EKG and RESP signals and a
sampling rate, or ekg.Ekg, or resp.Resp objects.

Already in __init__:
Coupling takes the phase of RESP, and from the EKG the R-R intervals
(rri) and R-peak heights (rph).  It fits a sinfunc to the two
relationship

phase -> rri
phase -> rph

sinfunc:
f(x) = p[0]+p[1] sin(x-p[2])

The two sets of optimal parameters p are saved in self.p_rri, and
self.p_rph.  Furthermore, the residual after fitting is saved in
self.res_rri, self.res_rph.

From these values, a Signal-to-Noise ratio SNR is saved in
self.snr_rri, and self.snr_rph.

Optimization is done using scipy.optimize.fmin (simplex downhill).

Methods
- Coupling.plot:  Shows the two fits.

Dependency
- fastcache is used to wrap scipy.signal.butter calls.

Other changes:

- Added feature.py to root directory containing a dev example.